### PR TITLE
Filter out redundant expressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9341,7 +9341,7 @@
     },
     "lively-javascript": {
       "version": "https://github.com/anthonykoch/lively-javascript/tarball/master",
-      "integrity": "sha512-CckP5p4wR4Kg2W88gl68COvkJjTNJb1RbLS4hHi8KXTJE2UjRmG2Pl9MeEd3Obqqrv972qvAiP+zI5Ii97PNTg==",
+      "integrity": "sha512-2ddZy4BESAI4Ow01qx9y+S+zdGsVEg/53SOQk7kCMRKQuxPufHNHaXauyJZKdAN36lF0v+BgD2O0Y719WpS4og==",
       "requires": {
         "@babel/core": "7.0.0-beta.40",
         "@babel/generator": "7.0.0-beta.40",


### PR DESCRIPTION
### What?
Expressions coming from literal values will no longer be shown since they are redundant information. 

The current behaviour is to log all expressions such as:

```
var a = 123;
123
```

However, since the literal is well, literal, this becomes redundant, so with this pr the phantoms for literal values will no longer be shown. Coverage is still shown for these lines, but the phantom showing the literal's value is being removed.